### PR TITLE
Remove Markdown preview in post preview section

### DIFF
--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -2,7 +2,6 @@ import { Field, Form, Formik } from 'formik'
 import getGravatar from 'gravatar'
 import React, { useEffect, useRef, useState } from 'react'
 import Avatar from './Avatar'
-import Markdown from './Markdown'
 
 const ForgotPassword = ({ setMessage, setParentView, supabase, apiHost }) => {
   const [loading, setLoading] = useState(false)
@@ -344,7 +343,7 @@ export default function Authentication({
         <div className='squeak-post-preview-container'>
           <div className='squeak-post-preview'>
             {formValues?.subject && <h3>{formValues.subject}</h3>}
-            <Markdown>{formValues.question}</Markdown>
+            {formValues.question}
           </div>
           <div className='squeak-button-container'>
             <button onClick={() => setParentView('question-form')}>

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -215,6 +215,8 @@ export const Theme = createGlobalStyle`
             display: flex;
             flex: 1;
             min-width: 0;
+            white-space: nowrap;
+            overflow: hidden;
         }
 
         h3, p {
@@ -228,6 +230,7 @@ export const Theme = createGlobalStyle`
             font-size: 1em;
             font-weight: 700;
             margin: 0 .5em 0 0;
+            flex-shrink: 0;
         }
 
         .squeak-post-markdown {


### PR DESCRIPTION
Displays body as text in post preview section / hides overflow

<img width="468" alt="Screen Shot 2022-04-17 at 11 42 44 PM" src="https://user-images.githubusercontent.com/28248250/163767045-3cf79f1b-a523-4542-b704-a0e1cd409f94.png">
