### PR TITLE
Add collapsible threads

### DIFF
--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -41,6 +41,7 @@ const Collapsed = ({ setExpanded }) => {
       </li>
 
       <li
+        key={reply?.id}
         className={`${resolvedBy === reply?.id ? 'squeak-solution' : ''} ${
           !reply?.published ? 'squeak-reply-unpublished' : ''
         }`}

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -19,7 +19,6 @@ const getBadge = (questionAuthorId, replyAuthorId, replyAuthorRole) => {
 
 const Collapsed = ({
   reply,
-  isModerator,
   resolvedBy,
   handlePublish,
   handleReplyDelete,
@@ -60,7 +59,6 @@ const Collapsed = ({
           resolved={resolved}
           resolvedBy={resolvedBy}
           handleResolve={handleResolve}
-          isModerator={isModerator}
           isAuthor={user?.profile?.id === questionAuthorId}
           {...reply}
           badgeText={badgeText}
@@ -72,7 +70,6 @@ const Collapsed = ({
 
 const Expanded = ({
   replies,
-  isModerator,
   resolvedBy,
   handlePublish,
   handleReplyDelete,
@@ -104,7 +101,6 @@ const Expanded = ({
           resolved={resolved}
           resolvedBy={resolvedBy}
           handleResolve={handleResolve}
-          isModerator={isModerator}
           isAuthor={user?.profile?.id === questionAuthorId}
           {...reply}
           badgeText={badgeText}
@@ -124,9 +120,6 @@ export default function Question({ question, onSubmit, onResolve, ...other }) {
   const [resolved, setResolved] = useState(question?.resolved)
   const [expanded, setExpanded] = useState(false)
   const questionAuthorId = firstReply?.profile?.id || null
-  const userMetadata = user?.profile?.metadata[0]
-  const isModerator =
-    userMetadata?.role === 'admin' || userMetadata?.role === 'moderator'
   const handleResolve = async (resolved, replyId = null) => {
     await fetch(`${apiHost}/api/question/resolve`, {
       method: 'POST',
@@ -171,7 +164,7 @@ export default function Question({ question, onSubmit, onResolve, ...other }) {
   useEffect(() => {
     setReplies(
       other.replies.filter(
-        (reply) => reply.published || (!reply.published && isModerator)
+        (reply) => reply.published || (!reply.published && user?.isModerator)
       )
     )
   }, [other.replies, user])
@@ -200,7 +193,6 @@ export default function Question({ question, onSubmit, onResolve, ...other }) {
           {expanded || replies.length <= 2 ? (
             <Expanded
               replies={replies.slice(1)}
-              isModerator={isModerator}
               resolvedBy={resolvedBy}
               handlePublish={handlePublish}
               handleReplyDelete={handleReplyDelete}
@@ -211,7 +203,6 @@ export default function Question({ question, onSubmit, onResolve, ...other }) {
             />
           ) : (
             <Collapsed
-              isModerator={isModerator}
               resolvedBy={resolvedBy}
               handlePublish={handlePublish}
               handleReplyDelete={handleReplyDelete}

--- a/src/components/Reply.js
+++ b/src/components/Reply.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useQuestion } from '../hooks/useQuestion'
 import { useUser } from '../hooks/useUser'
 import Avatar from './Avatar'
 import Days from './Days'
@@ -10,22 +11,26 @@ export default function Reply({
   body,
   subject,
   badgeText,
-  resolved,
-  resolvedBy,
-  isAuthor,
-  handleResolve,
   id,
   published,
-  handlePublish,
   ...other
 }) {
+  const question = useQuestion()
+  const {
+    questionAuthorId,
+    resolved,
+    resolvedBy,
+    handleResolve,
+    handlePublish
+  } = question
   const [confirmDelete, setConfirmDelete] = useState(false)
   const user = useUser()
   const isModerator = user?.isModerator
+  const isAuthor = user?.profile?.id === questionAuthorId
   const handleDelete = (e) => {
     e.stopPropagation()
     if (confirmDelete) {
-      other.handleDelete(id)
+      question.handleDelete(id)
     } else {
       setConfirmDelete(true)
     }
@@ -61,29 +66,31 @@ export default function Reply({
       <div className='squeak-post-content'>
         {subject && <h3>{subject}</h3>}
         <Markdown>{body}</Markdown>
-        <div className='squeak-reply-action-buttons'>
-          {!resolved && (isAuthor || isModerator) && (
-            <button
-              onClick={() => handleResolve(true, id)}
-              className='squeak-resolve-button'
-            >
-              Mark as solution
-            </button>
-          )}
-          {isModerator && (
-            <button
-              onClick={() => handlePublish(id, !published)}
-              className='squeak-publish-button'
-            >
-              {published ? 'Unpublish' : 'Publish'}
-            </button>
-          )}
-          {isModerator && (
-            <button onClick={handleDelete} className='squeak-delete-button'>
-              {confirmDelete ? 'Click again to confirm' : 'Delete'}
-            </button>
-          )}
-        </div>
+        {!subject && (
+          <div className='squeak-reply-action-buttons'>
+            {!resolved && (isAuthor || isModerator) && (
+              <button
+                onClick={() => handleResolve(true, id)}
+                className='squeak-resolve-button'
+              >
+                Mark as solution
+              </button>
+            )}
+            {isModerator && (
+              <button
+                onClick={() => handlePublish(id, !published)}
+                className='squeak-publish-button'
+              >
+                {published ? 'Unpublish' : 'Publish'}
+              </button>
+            )}
+            {isModerator && (
+              <button onClick={handleDelete} className='squeak-delete-button'>
+                {confirmDelete ? 'Click again to confirm' : 'Delete'}
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/Reply.js
+++ b/src/components/Reply.js
@@ -21,7 +21,8 @@ export default function Reply({
     resolved,
     resolvedBy,
     handleResolve,
-    handlePublish
+    handlePublish,
+    handleReplyDelete
   } = question
   const [confirmDelete, setConfirmDelete] = useState(false)
   const user = useUser()
@@ -30,13 +31,13 @@ export default function Reply({
   const handleDelete = (e) => {
     e.stopPropagation()
     if (confirmDelete) {
-      question.handleDelete(id)
+      handleReplyDelete(id)
     } else {
       setConfirmDelete(true)
     }
   }
 
-  const handleContainerClick = (e) => {
+  const handleContainerClick = () => {
     setConfirmDelete(false)
   }
 

--- a/src/components/Reply.js
+++ b/src/components/Reply.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useUser } from '../hooks/useUser'
 import Avatar from './Avatar'
 import Days from './Days'
 import Markdown from './Markdown'
@@ -14,13 +15,13 @@ export default function Reply({
   isAuthor,
   handleResolve,
   id,
-  isModerator,
   published,
   handlePublish,
   ...other
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
-
+  const user = useUser()
+  const isModerator = user?.isModerator
   const handleDelete = (e) => {
     e.stopPropagation()
     if (confirmDelete) {

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -5,7 +5,8 @@ import lightOrDark from '../util/lightOrDark'
 
 const Style = createGlobalStyle`
 :host {
-    --primary-color: ${(props) => props.dark ? '255, 255, 255' : '0, 0, 0'}; // rgb triplets, no hex
+    --primary-color: ${(props) =>
+      props.dark ? '255, 255, 255' : '0, 0, 0'}; // rgb triplets, no hex
     --button-color: var(--squeak-button-color, 29, 74, 255); // rgb triplet, no hex
     --border-radius: var(--squeak-border-radius, .25rem); // adjusts all radii
     --base-font-size: var(--squeak-base-font-size, 16px);
@@ -727,8 +728,10 @@ const Style = createGlobalStyle`
         }
     }
 
+   
+
     .squeak-resolve-button,
-    .squeak-undo-resolved, .squeak-publish-button {
+    .squeak-undo-resolved, .squeak-publish-button, .squeak-other-replies {
         background: none;
         border: none;
         padding: 0;
@@ -745,10 +748,14 @@ const Style = createGlobalStyle`
         font-weight: 600;
         margin-left: .5rem;
     }
-    .squeak-resolve-button, .squeak-unresolve-button, .squeak-resolve-text, .squeak-publish-button {
+    .squeak-resolve-button, .squeak-unresolve-button, .squeak-resolve-text, .squeak-publish-button, .squeak-other-replies {
         font-size: .875em;
         font-weight: 600;
         z-index: 1;
+    }
+
+    .squeak-other-replies {
+        padding-bottom: 2rem;
     }
 
     .squeak-resolved-badge {

--- a/src/context/question.js
+++ b/src/context/question.js
@@ -1,0 +1,92 @@
+import React, { createContext, useEffect, useState } from 'react'
+import { useClient } from 'react-supabase'
+import { useOrg } from '../hooks/useOrg'
+import { useUser } from '../hooks/useUser'
+
+export const Context = createContext({})
+export const Provider = ({
+  children,
+  question,
+  onResolve,
+  onSubmit,
+  ...other
+}) => {
+  const supabase = useClient()
+  const { organizationId, apiHost } = useOrg()
+  const user = useUser()
+  const [replies, setReplies] = useState([])
+  const [resolvedBy, setResolvedBy] = useState(question?.resolved_reply_id)
+  const [resolved, setResolved] = useState(question?.resolved)
+  const [firstReply] = replies
+  const questionAuthorId = firstReply?.profile?.id || null
+  const handleResolve = async (resolved, replyId = null) => {
+    await fetch(`${apiHost}/api/question/resolve`, {
+      method: 'POST',
+      body: JSON.stringify({
+        token: supabase.auth?.session()?.access_token,
+        messageId: question?.id,
+        replyId,
+        organizationId,
+        resolved
+      })
+    })
+    setResolved(resolved)
+    setResolvedBy(replyId)
+    if (onResolve) {
+      onResolve(resolved, replyId)
+    }
+  }
+
+  const handleReplyDelete = async (id) => {
+    await supabase
+      .from('squeak_replies')
+      .delete()
+      .match({ id, organization_id: organizationId })
+    setReplies(replies.filter((reply) => id !== reply.id))
+  }
+
+  const handlePublish = async (id, published) => {
+    await supabase
+      .from('squeak_replies')
+      .update({ published })
+      .match({ id, organization_id: organizationId })
+    const newReplies = [...replies]
+    newReplies.some((reply) => {
+      if (reply.id === id) {
+        reply.published = published
+        return true
+      }
+    })
+    setReplies(newReplies)
+  }
+
+  useEffect(() => {
+    setReplies(
+      other.replies.filter(
+        (reply) => reply.published || (!reply.published && user?.isModerator)
+      )
+    )
+  }, [other.replies, user])
+
+  useEffect(() => {
+    setResolved(question.resolved)
+  }, [question.resolved])
+
+  useEffect(() => {
+    setResolvedBy(question.resolved_reply_id)
+  }, [question.resolved_reply_id])
+
+  const value = {
+    replies,
+    resolvedBy,
+    resolved,
+    questionAuthorId,
+    question,
+    onSubmit,
+    handleResolve,
+    handleReplyDelete,
+    handlePublish
+  }
+
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}

--- a/src/context/user.js
+++ b/src/context/user.js
@@ -27,8 +27,11 @@ export const Provider = ({ children }) => {
   useEffect(() => {
     if (user && !user?.profile) {
       getProfile(user).then((profile) => {
+        const userMetadata = profile?.metadata[0]
+        const isModerator =
+          userMetadata?.role === 'admin' || userMetadata?.role === 'moderator'
         if (profile) {
-          setUser({ ...user, profile })
+          setUser({ ...user, profile, isModerator })
         }
       })
     }

--- a/src/hooks/useQuestion.js
+++ b/src/hooks/useQuestion.js
@@ -1,0 +1,7 @@
+import { useContext } from 'react'
+import { Context } from '../context/question'
+
+export const useQuestion = () => {
+  const question = useContext(Context)
+  return question
+}


### PR DESCRIPTION
- Automatically renders threads as collapsed with _only_  the solution shown (if there is one) otherwise the last message is shown.
- A button appears in place of the rest of the messages with the count of the rest of the replies. Clicking this button expands the thread to show the rest of the messages.

<img width="462" alt="Screen Shot 2022-04-20 at 5 17 48 PM" src="https://user-images.githubusercontent.com/28248250/164345013-69e5e855-bbde-4123-a006-af499946a36f.png">

