### PR TITLE
Allow primary color override

### DIFF
--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -5,10 +5,10 @@ import lightOrDark from '../util/lightOrDark'
 
 const Style = createGlobalStyle`
 :host {
-    --primary-color: ${(props) =>
-      props.dark ? '255, 255, 255' : '0, 0, 0'}; // rgb triplets, no hex
-    --default-avatar-fill: ${(props) =>
-    props.dark ? '0, 0, 0' : '255, 255, 255'}; // rgb triplets, no hex
+    --primary-color: var(--squeak-primary-color, ${(props) =>
+      props.dark ? '255, 255, 255' : '0, 0, 0'}); // rgb triplets, no hex
+    --default-avatar-fill: var(--squeak-default-avatar-fill, ${(props) =>
+      props.dark ? '0, 0, 0' : '255, 255, 255'}); // rgb triplets, no hex
     --button-color: var(--squeak-button-color, 29, 74, 255); // rgb triplet, no hex
     --button-weight: bold; // normal | bold | 600 | etc
     --border-radius: var(--squeak-border-radius, .25rem); // adjusts all radii


### PR DESCRIPTION
- Allows users to override the default primary color which is determined by the parent element's background color.

Currently, text color changes based on background color (dark or light). This calculation only happens on the first render which means dark mode toggles don't work as intended (the page needs to be reloaded before the component recognizes the new background color)

Now users can override the primary color variable with pure CSS. Example if using a `.dark` body class:

```
:root {
    --squeak-primary-color: 0, 0, 0;
    --squeak-default-avatar-fill: 255, 255, 255;
    .dark {
        --squeak-primary-color: 255, 255, 255;
        --squeak-default-avatar-fill: 0, 0, 0;
    }
}
```