### PR TITLE
Supabase refactor

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 120
+}

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ const Example = () => {
   return (
     <Squeak
       apiHost='YOUR_API_HOST'
-      apiKey='YOUR_SUPABASE_ANON_KEY'
-      url='YOUR_SUPABASE_URL'
       organizationId='YOUR_ORGANIZATION_ID'
     />
   )

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
+import { Squeak } from '../../src/components/main/Squeak'
+
 ReactDOM.render(
   <div style={{ maxWidth: 450 }}>
     <Squeak
-      apiHost='YOUR_API_HOST'
-      apiKey='YOUR_SUPABASE_ANON_KEY'
-      url='YOUR_SUPABASE_URL'
-      organizationId='YOUR_ORGANIZATION_ID'
+      apiHost='http://localhost:3001'
+      organizationId='a898bcf2-c5b9-4039-82a0-a00220a8c626'
     />
   </div>,
   document.getElementById('demo')

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,10 +5,7 @@ import { Squeak } from '../../src/components/main/Squeak'
 
 ReactDOM.render(
   <div style={{ maxWidth: 450 }}>
-    <Squeak
-      apiHost='http://localhost:3001'
-      organizationId='a898bcf2-c5b9-4039-82a0-a00220a8c626'
-    />
+    <Squeak apiHost='http://localhost:3001' organizationId='YOUR_ORG_ID' />
   </div>,
   document.getElementById('demo')
 )

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
-    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",
@@ -37,12 +36,15 @@
     "styled-reset": "^4.3.4"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": "^17.0.2"
   },
   "devDependencies": {
+    "eslint": "^8.20.0",
+    "eslint-config-prettier": "^8.5.0",
     "nwb": "0.25.x",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "prettier": "^2.7.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "homepage": "",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squeak-react",
-  "version": "3.0.0-pre.3",
+  "version": "3.0.0-pre.4",
   "description": "Squeak react",
   "author": "smallbrownbike",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squeak-react",
-  "version": "3.0.0-pre.1",
+  "version": "3.0.0-pre.2",
   "description": "Squeak react",
   "author": "smallbrownbike",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squeak-react",
-  "version": "3.0.0-pre.4",
+  "version": "3.0.0",
   "description": "Squeak react",
   "author": "smallbrownbike",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,12 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^1.31.2",
     "formik": "^2.2.9",
     "gravatar": "^1.8.2",
     "prism-react-renderer": "^1.3.1",
     "query-string": "^7.1.1",
     "react-markdown": "^8.0.2",
     "react-shadow": "^19.0.3",
-    "react-supabase": "^0.2.0",
     "rehype-sanitize": "^5.0.1",
     "styled-components": "^5.3.3",
     "styled-reset": "^4.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squeak-react",
-  "version": "3.0.0-pre.2",
+  "version": "3.0.0-pre.3",
   "description": "Squeak react",
   "author": "smallbrownbike",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",
-    "test:watch": "nwb test-react --server"
+    "test:watch": "nwb test-react --server",
+    "prerelease": "npm version prerelease && npm publish --tag next"
   },
   "dependencies": {
     "formik": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
-    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squeak-react",
-  "version": "2.0.0",
+  "version": "3.0.0-pre",
   "description": "Squeak react",
   "author": "smallbrownbike",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squeak-react",
-  "version": "3.0.0-pre",
+  "version": "3.0.0-pre.1",
   "description": "Squeak react",
   "author": "smallbrownbike",
   "license": "MIT",

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -1,24 +1,17 @@
 import { Field, Form, Formik } from 'formik'
 import getGravatar from 'gravatar'
 import React, { useEffect, useRef, useState } from 'react'
-import { useClient } from 'react-supabase'
 import { useOrg } from '../hooks/useOrg'
 import { useUser } from '../hooks/useUser'
 import { post } from '../lib/api'
 import Avatar from './Avatar'
 
 const ForgotPassword = ({ setMessage, setParentView, apiHost }) => {
-  const supabase = useClient()
   const [loading, setLoading] = useState(false)
   const [emailSent, setEmailSent] = useState(false)
   const handleSubmit = async (values) => {
     setLoading(true)
-    const { error } = await supabase.auth.api.resetPasswordForEmail(
-      values.email,
-      {
-        redirectTo: `${apiHost}/reset-password`
-      }
-    )
+    const { error } = await post(apiHost, '/api/password/forgot')
     if (error) {
       setMessage(error.message)
     } else {
@@ -266,13 +259,13 @@ const SignUp = ({
   )
 }
 
-const ResetPassword = ({ setMessage, setParentView }) => {
-  const supabase = useClient()
+const ResetPassword = ({ setMessage, setParentView, apiHost }) => {
   const [loading, setLoading] = useState(false)
   const resetPassword = useRef()
+
   const handleSubmit = async (values) => {
     setLoading(true)
-    const { error } = await supabase.auth.update({
+    const { error } = await post(apiHost, '/api/password/reset', {
       password: values.password
     })
     if (error) {
@@ -429,6 +422,7 @@ export default function Authentication({
                   <ResetPassword
                     setParentView={setParentView}
                     setMessage={setMessage}
+                    apiHost={apiHost}
                   />
                 )
               }[view]

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -89,20 +89,24 @@ const SignIn = ({
   setMessage,
   handleMessageSubmit,
   formValues,
+  apiHost,
   buttonText
 }) => {
-  const supabase = useClient()
   const [loading, setLoading] = useState(false)
   const handleSubmit = async (values) => {
     setLoading(true)
-    const { error } = await supabase.auth.signIn(values)
+    const { data, error } = await post(apiHost, '/api/login', {
+      email: values.email,
+      password: values.password
+    })
     if (error) {
-      setMessage(error.message)
+      setMessage('Incorrect email/password. Please try again.')
       setLoading(false)
     } else {
       await handleMessageSubmit(formValues)
     }
   }
+
   return (
     <Formik
       validateOnMount
@@ -401,6 +405,7 @@ export default function Authentication({
                     formValues={formValues}
                     handleMessageSubmit={handleMessageSubmit}
                     setMessage={setMessage}
+                    apiHost={apiHost}
                   />
                 ),
                 'sign-up': (

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -86,6 +86,8 @@ const SignIn = ({
   buttonText
 }) => {
   const [loading, setLoading] = useState(false)
+  const { setUser } = useUser()
+
   const handleSubmit = async (values) => {
     setLoading(true)
     const { data, error } = await post(apiHost, '/api/login', {
@@ -96,6 +98,7 @@ const SignIn = ({
       setMessage('Incorrect email/password. Please try again.')
       setLoading(false)
     } else {
+      setUser({ id: data.id })
       await handleMessageSubmit(formValues)
     }
   }

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -9,11 +9,14 @@ import Avatar from './Avatar'
 const ForgotPassword = ({ setMessage, setParentView, apiHost }) => {
   const [loading, setLoading] = useState(false)
   const [emailSent, setEmailSent] = useState(false)
+  const { organizationId } = useOrg()
+
   const handleSubmit = async (values) => {
     setLoading(true)
     const { error } = await post(apiHost, '/api/password/forgot', {
       email: values.email,
-      redirect: window.location.href
+      redirect: window.location.href,
+      organizationId
     })
     if (error) {
       setMessage(error.message)

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -11,7 +11,10 @@ const ForgotPassword = ({ setMessage, setParentView, apiHost }) => {
   const [emailSent, setEmailSent] = useState(false)
   const handleSubmit = async (values) => {
     setLoading(true)
-    const { error } = await post(apiHost, '/api/password/forgot')
+    const { error } = await post(apiHost, '/api/password/forgot', {
+      email: values.email,
+      redirect: window.location.href
+    })
     if (error) {
       setMessage(error.message)
     } else {

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -21,12 +21,7 @@ const getBadge = (questionAuthorId, replyAuthorId, replyAuthorRole) => {
 }
 
 const Collapsed = ({ setExpanded }) => {
-  const {
-    replies,
-    resolvedBy,
-    questionAuthorId,
-    id: questionId
-  } = useQuestion()
+  const { replies, resolvedBy, questionAuthorId } = useQuestion()
   const reply =
     replies[replies.findIndex((reply) => reply?.id === resolvedBy)] ||
     replies[replies.length - 1]

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+
 import { Provider as QuestionProvider } from '../context/question'
 import { useOrg } from '../hooks/useOrg'
 import { useQuestion } from '../hooks/useQuestion'
@@ -87,31 +88,41 @@ const Collapsed = ({ setExpanded }) => {
   )
 }
 
-const Expanded = ({}) => {
+const Expanded = () => {
   const question = useQuestion()
   const replies = question.replies?.slice(1)
   const { resolvedBy, questionAuthorId } = question
-  return replies.map((reply) => {
-    const replyAuthorMetadata =
-      reply?.profile?.profiles_readonly?.[0] || reply?.profile?.metadata?.[0]
 
-    const badgeText = getBadge(
-      questionAuthorId,
-      reply?.profile?.id,
-      replyAuthorMetadata?.role
-    )
+  return (
+    <>
+      {replies.map((reply) => {
+        const replyAuthorMetadata =
+          reply?.profile?.profiles_readonly?.[0] ||
+          reply?.profile?.metadata?.[0]
 
-    return (
-      <li
-        key={reply.id}
-        className={`${resolvedBy === reply.id ? 'squeak-solution' : ''} ${
-          !reply.published ? 'squeak-reply-unpublished' : ''
-        }`}
-      >
-        <Reply className='squeak-post-reply' {...reply} badgeText={badgeText} />
-      </li>
-    )
-  })
+        const badgeText = getBadge(
+          questionAuthorId,
+          reply?.profile?.id,
+          replyAuthorMetadata?.role
+        )
+
+        return (
+          <li
+            key={reply.id}
+            className={`${resolvedBy === reply.id ? 'squeak-solution' : ''} ${
+              !reply.published ? 'squeak-reply-unpublished' : ''
+            }`}
+          >
+            <Reply
+              className='squeak-post-reply'
+              {...reply}
+              badgeText={badgeText}
+            />
+          </li>
+        )
+      })}
+    </>
+  )
 }
 
 const Replies = ({ expanded, setExpanded }) => {
@@ -153,6 +164,7 @@ export default function Question({ onSubmit, onResolve, apiHost, ...other }) {
   const [question, setQuestion] = useState(other.question)
   const [replies, setReplies] = useState(other.replies || [])
   const [firstReply] = replies
+
   const {
     organizationId,
     config: { permalink_base, permalinks_enabled }
@@ -171,13 +183,13 @@ export default function Question({ onSubmit, onResolve, apiHost, ...other }) {
   }
 
   useEffect(() => {
-    if (!question) {
+    if (!question && permalink_base) {
       getQuestion().then((question) => {
         setQuestion(question?.question)
         setReplies(question?.replies || [])
       })
     }
-  }, [])
+  }, [organizationId, permalink_base])
 
   return question ? (
     <div className='squeak-question-container'>

--- a/src/components/QuestionForm.js
+++ b/src/components/QuestionForm.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { useClient } from 'react-supabase'
 import { useOrg } from '../hooks/useOrg'
 import { useUser } from '../hooks/useUser'
+import { post } from '../lib/api'
 import { Approval } from './Approval'
 import Authentication from './Authentication'
 import Avatar from './Avatar'
@@ -109,33 +110,27 @@ export default function ({ formType = 'question', messageID, onSubmit }) {
     )
 
   const insertReply = async ({ body, messageID }) => {
-    return fetch(`${apiHost}/api/reply`, {
-      method: 'POST',
-      body: JSON.stringify({
-        body,
-        organizationId,
-        messageId: messageID,
-        token: supabase.auth.session()?.access_token
-      })
-    }).then((res) => res.json())
+    const { data } = await post(apiHost, '/api/reply', {
+      body,
+      organizationId,
+      messageId: messageID
+    })
+    return data
   }
 
   const insertMessage = async ({ subject, body, userID }) => {
-    return fetch(`${apiHost}/api/question`, {
-      method: 'POST',
-      body: JSON.stringify({
-        subject,
-        body,
-        organizationId,
-        token: supabase.auth.session()?.access_token,
-        slug: window.location.pathname.replace(/\/$/, '')
-      })
-    }).then((res) => res.json())
+    const { data } = await post(apiHost, '/api/question', {
+      subject,
+      body,
+      organizationId,
+      slug: window.location.pathname.replace(/\/$/, '')
+    })
+    return data
   }
 
   const handleMessageSubmit = async (values) => {
     setLoading(true)
-    const userID = supabase.auth.user()?.id
+    const userID = user.id
     if (userID) {
       let view = null
       if (formType === 'question') {

--- a/src/components/QuestionForm.js
+++ b/src/components/QuestionForm.js
@@ -1,6 +1,6 @@
 import { Field, Form, Formik } from 'formik'
 import React, { useState } from 'react'
-import { useClient } from 'react-supabase'
+
 import { useOrg } from '../hooks/useOrg'
 import { useUser } from '../hooks/useUser'
 import { post } from '../lib/api'
@@ -17,7 +17,7 @@ function QuestionForm({
   loading,
   initialValues
 }) {
-  const user = useUser()
+  const { user } = useUser()
   const handleSubmit = async (values) => {
     onSubmit && (await onSubmit(values))
   }
@@ -94,9 +94,8 @@ function QuestionForm({
 }
 
 export default function ({ formType = 'question', messageID, onSubmit }) {
-  const supabase = useClient()
   const { organizationId, apiHost } = useOrg()
-  const user = useUser()
+  const { user, setUser } = useUser()
   const [formValues, setFormValues] = useState(null)
   const [view, setView] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -130,7 +129,7 @@ export default function ({ formType = 'question', messageID, onSubmit }) {
 
   const handleMessageSubmit = async (values) => {
     setLoading(true)
-    const userID = user.id
+    const userID = user?.id
     if (userID) {
       let view = null
       if (formType === 'question') {

--- a/src/components/QuestionForm.js
+++ b/src/components/QuestionForm.js
@@ -164,6 +164,11 @@ export default function ({ formType = 'question', messageID, onSubmit }) {
     }
   }
 
+  const doLogout = async () => {
+    await post(apiHost, '/api/logout')
+    setUser(null)
+  }
+
   return view ? (
     {
       'question-form': (
@@ -215,7 +220,7 @@ export default function ({ formType = 'question', messageID, onSubmit }) {
         <button
           onClick={() => {
             if (user) {
-              supabase.auth.signOut()
+              doLogout()
             } else {
               setView('login')
             }

--- a/src/components/Questions.js
+++ b/src/components/Questions.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useOrg } from '../hooks/useOrg'
-import { get, post } from '../lib/api'
+import { post } from '../lib/api'
 import Question from './Question'
 import QuestionForm from './QuestionForm'
 

--- a/src/components/Questions.js
+++ b/src/components/Questions.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useOrg } from '../hooks/useOrg'
+import { get, post } from '../lib/api'
 import Question from './Question'
 import QuestionForm from './QuestionForm'
 
@@ -20,7 +21,7 @@ const Topics = ({ handleTopicChange, activeTopic }) => {
         </li>
         {topics.map(({ label }) => {
           return (
-            <li>
+            <li key={label}>
               <button
                 className={activeTopic === label ? 'squeak-active-topic' : ''}
                 onClick={() => handleTopicChange(label)}
@@ -42,25 +43,25 @@ export default function Questions({
   const [activeTopic, setActiveTopic] = useState(null)
   const { organizationId, apiHost } = useOrg()
   const [questions, setQuestions] = useState([])
+
   const getQuestions = async (topic) => {
-    const response = await fetch(`${apiHost}/api/questions`, {
-      method: 'GET',
-      body: JSON.stringify({
+    const { response, data: questions } = await post(
+      apiHost,
+      `/api/questions`,
+      {
         organizationId,
         slug,
         published: true,
         perPage: 100,
         topic
-      })
-    })
+      }
+    )
 
     if (response.status !== 200) {
       return []
     }
 
-    const { questions } = await response.json()
-
-    return questions
+    return questions.questions
   }
 
   useEffect(() => {

--- a/src/components/Questions.js
+++ b/src/components/Questions.js
@@ -44,7 +44,7 @@ export default function Questions({
   const [questions, setQuestions] = useState([])
   const getQuestions = async (topic) => {
     const response = await fetch(`${apiHost}/api/questions`, {
-      method: 'POST',
+      method: 'GET',
       body: JSON.stringify({
         organizationId,
         slug,

--- a/src/components/Reply.js
+++ b/src/components/Reply.js
@@ -26,7 +26,7 @@ export default function Reply({
     handleReplyDelete
   } = question
   const [confirmDelete, setConfirmDelete] = useState(false)
-  const user = useUser()
+  const { user } = useUser()
   const isModerator = user?.isModerator
   const isAuthor = user?.profile?.id === questionAuthorId
   const handleDelete = (e) => {

--- a/src/components/RichText.js
+++ b/src/components/RichText.js
@@ -149,7 +149,7 @@ export default function RichText({ initialValue = '', setFieldValue }) {
         required
         id='question'
         placeholder='Type more details...'
-        maxLength='2000'
+        maxLength={2000}
       />
       <div className='squeak-form-richtext-buttons-container'>
         <ul className='squeak-form-richtext-buttons'>
@@ -168,7 +168,12 @@ export default function RichText({ initialValue = '', setFieldValue }) {
           })}
         </ul>
         <div className='squeak-markdown-logo'>
-          <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank" rel="noopener" title="Supports Markdown syntax">
+          <a
+            href='https://www.markdownguide.org/cheat-sheet/'
+            target='_blank'
+            rel='noopener'
+            title='Supports Markdown syntax'
+          >
             <MarkdownLogo />
           </a>
         </div>

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -38,7 +38,7 @@ const Style = createGlobalStyle`
         font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
         border-radius: 2px;
     }
-    
+
     button {
         background: transparent;
         border: solid 1.5px rgba(var(--button-color), .85);
@@ -286,7 +286,7 @@ const Style = createGlobalStyle`
                 padding-top: 1em;
             }
         }
-        
+
         .squeak-reply-buttons-row {
             margin-left: 35px;
         }
@@ -325,7 +325,7 @@ const Style = createGlobalStyle`
         .squeak-avatar-container {
             margin-right: 10px;
         }
-        
+
         > span:last-of-type {
             display: flex;
         }
@@ -359,7 +359,7 @@ const Style = createGlobalStyle`
 
         &:hover {
             border: solid 1.5px rgba(var(--primary-color), .5);
-            
+
             span {
                 color: rgba(var(--primary-color), .7);
 
@@ -522,7 +522,7 @@ const Style = createGlobalStyle`
             width: 25px;
         }
 
-        .squeak-avatar-container { 
+        .squeak-avatar-container {
             svg, img {
                 height: 25px;
                 width: 25px;
@@ -669,7 +669,7 @@ const Style = createGlobalStyle`
         list-style: none;
         padding: 0;
         margin: 0 0 0 0.5rem;
-        
+
         button {
             align-items: center;
             background: none;
@@ -756,7 +756,7 @@ const Style = createGlobalStyle`
         }
     }
 
-   
+
 
     .squeak-resolve-button,
     .squeak-undo-resolved, .squeak-publish-button, .squeak-other-replies {
@@ -825,7 +825,7 @@ const Style = createGlobalStyle`
             font-size: .875em;
         }
     }
-    
+
     .squeak-approval-required {
         padding-bottom: 1rem;
 

--- a/src/components/main/Form.js
+++ b/src/components/main/Form.js
@@ -1,28 +1,23 @@
-import { createClient } from '@supabase/supabase-js'
 import React, { useRef } from 'react'
 import root from 'react-shadow/styled-components'
-import { Provider as SupabaseProvider } from 'react-supabase'
 import { Provider as OrgProvider } from '../../context/org'
 import { Provider as UserProvider } from '../../context/user'
 import QuestionForm from '../QuestionForm'
 import { Theme } from '../Theme'
 
-export const Form = ({ apiKey, url, apiHost, organizationId, onSubmit }) => {
-  const supabase = createClient(url, apiKey)
+export const Form = ({ apiHost, organizationId, onSubmit }) => {
   const containerRef = useRef()
 
   return (
     <root.div ref={containerRef}>
-      <SupabaseProvider value={supabase}>
-        <OrgProvider value={{ organizationId, apiHost }}>
-          <UserProvider>
-            <Theme containerRef={containerRef} />
-            <div className='squeak'>
-              <QuestionForm onSubmit={onSubmit} />
-            </div>
-          </UserProvider>
-        </OrgProvider>
-      </SupabaseProvider>
+      <OrgProvider value={{ organizationId, apiHost }}>
+        <UserProvider>
+          <Theme containerRef={containerRef} />
+          <div className='squeak'>
+            <QuestionForm onSubmit={onSubmit} />
+          </div>
+        </UserProvider>
+      </OrgProvider>
     </root.div>
   )
 }

--- a/src/components/main/Question.js
+++ b/src/components/main/Question.js
@@ -15,7 +15,6 @@ export const Question = ({
   apiKey,
   ...other
 }) => {
-  console.log('rendering main question component updated')
   const containerRef = useRef()
   return (
     <root.div ref={containerRef}>

--- a/src/components/main/Question.js
+++ b/src/components/main/Question.js
@@ -1,7 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import React, { useRef } from 'react'
 import root from 'react-shadow/styled-components'
-import { Provider as SupabaseProvider } from 'react-supabase'
 import { Provider as OrgProvider } from '../../context/org'
 import { Provider as UserProvider } from '../../context/user'
 import SingleQuestion from '../Question'
@@ -17,26 +15,24 @@ export const Question = ({
   apiKey,
   ...other
 }) => {
+  console.log('rendering main question component updated')
   const containerRef = useRef()
-  const supabase = other.supabase || createClient(url, apiKey)
   return (
     <root.div ref={containerRef}>
-      <SupabaseProvider value={supabase}>
-        <OrgProvider value={{ organizationId, apiHost }}>
-          <UserProvider>
-            <Theme containerRef={containerRef} />
-            <div className='squeak'>
-              <SingleQuestion
-                apiHost={apiHost}
-                replies={question?.replies}
-                question={question?.question}
-                onSubmit={onSubmit}
-                onResolve={onResolve}
-              />
-            </div>
-          </UserProvider>
-        </OrgProvider>
-      </SupabaseProvider>
+      <OrgProvider value={{ organizationId, apiHost }}>
+        <UserProvider>
+          <Theme containerRef={containerRef} />
+          <div className='squeak'>
+            <SingleQuestion
+              apiHost={apiHost}
+              replies={question?.replies}
+              question={question?.question}
+              onSubmit={onSubmit}
+              onResolve={onResolve}
+            />
+          </div>
+        </UserProvider>
+      </OrgProvider>
     </root.div>
   )
 }

--- a/src/components/main/Squeak.js
+++ b/src/components/main/Squeak.js
@@ -1,35 +1,24 @@
-import { createClient } from '@supabase/supabase-js'
 import React, { useRef } from 'react'
 import root from 'react-shadow/styled-components'
-import { Provider as SupabaseProvider } from 'react-supabase'
+
 import { Provider as OrgProvider } from '../../context/org'
 import { Provider as UserProvider } from '../../context/user'
 import Questions from '../Questions'
 import { Theme } from '../Theme'
 
-export const Squeak = ({
-  apiKey,
-  url,
-  apiHost,
-  organizationId,
-  slug,
-  onSubmit
-}) => {
-  const supabase = createClient(url, apiKey)
+export const Squeak = ({ apiHost, organizationId, slug, onSubmit }) => {
   const containerRef = useRef()
 
   return (
     <root.div ref={containerRef}>
-      <SupabaseProvider value={supabase}>
-        <OrgProvider value={{ organizationId, apiHost }}>
-          <UserProvider>
-            <Theme containerRef={containerRef} />
-            <div className='squeak'>
-              <Questions onSubmit={onSubmit} slug={slug} />
-            </div>
-          </UserProvider>
-        </OrgProvider>
-      </SupabaseProvider>
+      <OrgProvider value={{ organizationId, apiHost }}>
+        <UserProvider>
+          <Theme containerRef={containerRef} />
+          <div className='squeak'>
+            <Questions onSubmit={onSubmit} slug={slug} />
+          </div>
+        </UserProvider>
+      </OrgProvider>
     </root.div>
   )
 }

--- a/src/context/org.js
+++ b/src/context/org.js
@@ -7,7 +7,7 @@ export const Provider = ({ value: { apiHost, organizationId }, children }) => {
 
   const getTopics = async () => {
     return await fetch(`${apiHost}/api/topics`, {
-      method: 'POST',
+      method: 'GET',
       body: JSON.stringify({
         organizationId
       })
@@ -16,7 +16,7 @@ export const Provider = ({ value: { apiHost, organizationId }, children }) => {
 
   const getConfig = async () => {
     return await fetch(`${apiHost}/api/config`, {
-      method: 'POST',
+      method: 'GET',
       body: JSON.stringify({
         organizationId
       })

--- a/src/context/org.js
+++ b/src/context/org.js
@@ -1,4 +1,5 @@
 import React, { createContext, useEffect, useState } from 'react'
+import { get, post } from '../lib/api'
 
 export const Context = createContext(undefined)
 export const Provider = ({ value: { apiHost, organizationId }, children }) => {
@@ -6,21 +7,13 @@ export const Provider = ({ value: { apiHost, organizationId }, children }) => {
   const [config, setConfig] = useState({})
 
   const getTopics = async () => {
-    return await fetch(`${apiHost}/api/topics`, {
-      method: 'GET',
-      body: JSON.stringify({
-        organizationId
-      })
-    }).then((res) => res.json())
+    const { data } = await post(apiHost, `/api/topics`, { organizationId })
+    return data
   }
 
   const getConfig = async () => {
-    return await fetch(`${apiHost}/api/config`, {
-      method: 'GET',
-      body: JSON.stringify({
-        organizationId
-      })
-    }).then((res) => res.json())
+    const { data } = await get(apiHost, '/api/config', { organizationId })
+    return data
   }
 
   useEffect(() => {

--- a/src/context/question.js
+++ b/src/context/question.js
@@ -42,7 +42,7 @@ export const Provider = ({
 
   const handlePublish = async (id, published) => {
     await patch(apiHost, `/api/replies/${id}`, {
-      organization_id: organizationId,
+      organizationId: organizationId,
       published
     })
     const newReplies = [...replies]

--- a/src/context/question.js
+++ b/src/context/question.js
@@ -10,11 +10,10 @@ export const Provider = ({
   question,
   onResolve,
   onSubmit,
-  replies: initialReplies,
   ...other
 }) => {
   const { organizationId, apiHost } = useOrg()
-  const user = useUser()
+  const { user } = useUser()
   const [replies, setReplies] = useState([])
   const [resolvedBy, setResolvedBy] = useState(question?.resolved_reply_id)
   const [resolved, setResolved] = useState(question?.resolved)
@@ -57,11 +56,11 @@ export const Provider = ({
 
   useEffect(() => {
     setReplies(
-      initialReplies.filter(
+      other.replies.filter(
         (reply) => reply.published || (!reply.published && user?.isModerator)
       )
     )
-  }, [initialReplies, user?.id])
+  }, [other.replies, user?.id])
 
   useEffect(() => {
     setResolved(question.resolved)

--- a/src/context/question.js
+++ b/src/context/question.js
@@ -4,11 +4,13 @@ import { useUser } from '../hooks/useUser'
 import { doDelete, patch, post } from '../lib/api'
 
 export const Context = createContext({})
+
 export const Provider = ({
   children,
   question,
   onResolve,
   onSubmit,
+  replies: initialReplies,
   ...other
 }) => {
   const { organizationId, apiHost } = useOrg()
@@ -55,11 +57,11 @@ export const Provider = ({
 
   useEffect(() => {
     setReplies(
-      other.replies.filter(
+      initialReplies.filter(
         (reply) => reply.published || (!reply.published && user?.isModerator)
       )
     )
-  }, [other.replies, user?.id])
+  }, [initialReplies, user?.id])
 
   useEffect(() => {
     setResolved(question.resolved)

--- a/src/context/user.js
+++ b/src/context/user.js
@@ -27,5 +27,7 @@ export const Provider = ({ children }) => {
       })
   }, [user?.id])
 
-  return <Context.Provider value={user}>{children}</Context.Provider>
+  return (
+    <Context.Provider value={{ user, setUser }}>{children}</Context.Provider>
+  )
 }

--- a/src/context/user.js
+++ b/src/context/user.js
@@ -1,41 +1,31 @@
 import React, { createContext, useEffect, useState } from 'react'
-import { useAuthStateChange, useClient } from 'react-supabase'
 import { useOrg } from '../hooks/useOrg'
+import { get } from '../lib/api'
 
 export const Context = createContext(undefined)
 export const Provider = ({ children }) => {
-  const supabase = useClient()
-  const [user, setUser] = useState(supabase.auth.user())
-  const { organizationId } = useOrg()
+  const [user, setUser] = useState(null)
+  const { organizationId, apiHost } = useOrg()
 
-  const getProfile = async (user) => {
-    const { data } = await supabase
-      .from('squeak_profiles_readonly')
-      .select(
-        'squeak_profiles!profiles_readonly_profile_id_fkey!inner(avatar, first_name, last_name, id, metadata:squeak_profiles_readonly(role))'
-      )
-      .match({ user_id: user?.id, organization_id: organizationId })
-      .single()
-
-    return data?.squeak_profiles
+  function getSession() {
+    return get(apiHost, '/api/user', { organizationId })
   }
 
-  useAuthStateChange(async (e, session) => {
-    setUser(session?.user)
-  })
-
   useEffect(() => {
-    if (user && !user?.profile) {
-      getProfile(user).then((profile) => {
-        const userMetadata = profile?.metadata[0]
-        const isModerator =
-          userMetadata?.role === 'admin' || userMetadata?.role === 'moderator'
-        if (profile) {
-          setUser({ ...user, profile, isModerator })
+    getSession()
+      .then(({ data, error }) => {
+        if (error) {
+          console.error('ERROR', data.error)
+        } else {
+          const role = data.profile?.role
+          const isModerator = role === 'admin' || role === 'moderator'
+          setUser({ ...data, isModerator })
         }
       })
-    }
-  }, [user])
+      .catch((err) => {
+        console.log('error getting session', err)
+      })
+  }, [user?.id])
 
   return <Context.Provider value={user}>{children}</Context.Provider>
 }

--- a/src/lib/api/client.js
+++ b/src/lib/api/client.js
@@ -1,0 +1,92 @@
+const FETCH_DEFAULTS = {
+  credentials: 'include',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+  }
+  // mode: 'cors'
+}
+
+function buildUrl(host, path) {
+  return host + path
+}
+
+export async function patch(host, url, body) {
+  try {
+    const res = await fetch(buildUrl(host, url), {
+      ...FETCH_DEFAULTS,
+      method: 'PATCH',
+      body: JSON.stringify(body)
+    })
+    return processResponse(res)
+  } catch (e) {
+    console.error('PATCH request error', e)
+    return { error: e }
+  }
+}
+
+export async function doDelete(host, url, body) {
+  try {
+    const res = await fetch(buildUrl(host, url), {
+      ...FETCH_DEFAULTS,
+      method: 'DELETE',
+      body: JSON.stringify(body)
+    })
+    return processResponse(res)
+  } catch (e) {
+    console.error('DELETE request error', e)
+    return { error: e }
+  }
+}
+
+export async function get(host, url, params) {
+  if (params) {
+    url += '?' + new URLSearchParams(params).toString()
+  }
+  try {
+    const res = await fetch(buildUrl(host, url), {
+      ...FETCH_DEFAULTS,
+      method: 'GET'
+    })
+    return processResponse(res)
+  } catch (e) {
+    console.error('GET request error', e)
+    return { error: e }
+  }
+}
+/**
+ * Submit a POST request
+ * @param  {string} host
+ * @param  {string} url
+ * @param  {any} body body is serialized as json
+ */
+export async function post(host, url, body) {
+  try {
+    const res = await fetch(buildUrl(host, url), {
+      ...FETCH_DEFAULTS,
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
+    return processResponse(res)
+  } catch (e) {
+    return { error: e }
+  }
+}
+
+/**
+ * Process the response according to it's status code. Success responses are deserialized as json.
+ * @param  {} res Response
+ */
+async function processResponse(res) {
+  if (res.status >= 200 && res.status <= 201) {
+    const data = await res.json()
+    return { data, response: res }
+  } else if (res.status === 400) {
+    const data = await res.json()
+    return { error: new Error(data?.error), response: res }
+  } else if (res.status === 401) {
+    return { error: new Error('Not authenticated'), response: res }
+  } else if (res.status >= 500) {
+    return { error: new Error('Unexpected error occurred'), response: res }
+  }
+}

--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -1,0 +1,1 @@
+export * from './client'

--- a/src/util/lightOrDark.js
+++ b/src/util/lightOrDark.js
@@ -3,12 +3,14 @@ export default function lightOrDark(color) {
     return 'light'
   }
   let r, g, b, hsp
-  color = color.match(
+  const colorMatch = color.match(
     /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/
   )
-  r = color[1]
-  g = color[2]
-  b = color[3]
+  if (!colorMatch) return 'light'
+
+  r = parseInt(colorMatch[1])
+  g = parseInt(colorMatch[2])
+  b = parseInt(colorMatch[3])
   hsp = Math.sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b))
   return hsp > 127.5 ? 'light' : 'dark'
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,53 +1232,6 @@
     native-url "^0.2.6"
     schema-utils "^2.6.5"
 
-"@supabase/functions-js@^1.3.2":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@supabase/functions-js/-/functions-js-1.3.3.tgz#74803fec71f1e3b734d32a3b116ea494cfcc122d"
-  integrity sha512-35vO9niHRtzGe1QSvXKdOfvGPiX2KC44dGpWU6y0/gZCfTIgog/soU9HqABzQC/maVowO3hGLWfez5aN0MKfow==
-  dependencies:
-    cross-fetch "^3.1.5"
-
-"@supabase/gotrue-js@^1.22.10":
-  version "1.22.12"
-  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-1.22.12.tgz#78caaef13ef9bdacfcbabceb803ac79de52c6ad3"
-  integrity sha512-/baPkNiumE2B+OLSpvZquDsTqnOTAsG/07GBq5rXU8/e0rSyjljAFf8gnawGPezjlDGTFr2fjRYs0BYMz4LD/A==
-  dependencies:
-    cross-fetch "^3.0.6"
-
-"@supabase/postgrest-js@^0.37.2":
-  version "0.37.2"
-  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-0.37.2.tgz#4243587eea5ad9507371fcdc4b3ec096d652ad03"
-  integrity sha512-3Dgx5k3RvtKqc8DvR2BEyh2fVyjZe5P4e0zD1r8dyuVmpaYDaASZ2YeNVgyWXMCWH7xzrj4vepTYlKwfj78QLg==
-  dependencies:
-    cross-fetch "^3.0.6"
-
-"@supabase/realtime-js@^1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-1.6.2.tgz#1fec4eabc9b01346006d6098d8cc29ebafa2b70a"
-  integrity sha512-0aK2WoCYvS2lO2BGQwPaxz91oq76lJ+/rSzAMUDFe8mZFj+v4ugifDMUHKpSxJWqW4u4OB9cs3zw11qWlQQCrw==
-  dependencies:
-    "@types/phoenix" "^1.5.4"
-    websocket "^1.0.34"
-
-"@supabase/storage-js@^1.6.5":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-1.7.0.tgz#42536489d8807d3feefe8fff9acff14efc0bad74"
-  integrity sha512-f5EBw0wM96hKmnrXhgiqq2Reh9O0NgjKE+jkaKY4jQmfutefqaCAWn+cBzlmHs9h135H2ldaGmhWRFHUSkLt2g==
-  dependencies:
-    cross-fetch "^3.1.0"
-
-"@supabase/supabase-js@^1.31.2":
-  version "1.33.3"
-  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-1.33.3.tgz#f5dadcea6c0d04bb4c93268c1e63ec9eec8b33bf"
-  integrity sha512-wQyCoP03bs21UvfVxRYrFTBmYSGMXjFAKlmP66MACqWUfYLKgJJ3/xVFfOLyyi7M8QTYw8XUK+z4yqQ5p1l88Q==
-  dependencies:
-    "@supabase/functions-js" "^1.3.2"
-    "@supabase/gotrue-js" "^1.22.10"
-    "@supabase/postgrest-js" "^0.37.2"
-    "@supabase/realtime-js" "^1.6.2"
-    "@supabase/storage-js" "^1.6.5"
-
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -1342,11 +1295,6 @@
   version "17.0.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.24.tgz#20ba1bf69c1b4ab405c7a01e950c4f446b05029f"
   integrity sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==
-
-"@types/phoenix@^1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.5.4.tgz#c08a1da6d7b4e365f6a1fe1ff9aada55f5356d24"
-  integrity sha512-L5eZmzw89eXBKkiqVBcJfU1QGx9y+wurRIEgt0cuLH0hwNtVUxtx+6cu0R2STwWj468sjXyBYPYDtGclUd1kjQ==
 
 "@types/prop-types@^15.0.0":
   version "15.7.5"
@@ -2337,13 +2285,6 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-bufferutil@^4.0.1:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.6.tgz#ebd6c67c7922a0e902f053e5d8be5ec850e48433"
-  integrity sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==
-  dependencies:
-    node-gyp-build "^4.3.0"
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -3014,13 +2955,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.6, cross-fetch@^3.1.0, cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
@@ -3276,14 +3210,6 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
-
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -3839,36 +3765,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.60"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.60.tgz#e8060a86472842b93019c31c34865012449883f4"
-  integrity sha512-jpKNXIt60htYG59/9FGf2PYT3pwMpnEbNKysU+k/4FGwyGtMotOvcZOuW+EmXXYASRqYSXQfGL5cVIthOTgbkg==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    next-tick "^1.1.0"
-
-es6-iterator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
 es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -4121,13 +4021,6 @@ express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-ext@^1.1.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
-  integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
-  dependencies:
-    type "^2.5.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -5612,7 +5505,7 @@ is-typed-array@^1.1.7:
     foreach "^2.0.5"
     has-tostringtag "^1.0.0"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -6850,11 +6743,6 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -6876,22 +6764,10 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
-node-gyp-build@^4.3.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.4.0.tgz#42e99687ce87ddeaf3a10b99dc06abc11021f3f4"
-  integrity sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==
 
 node-libs-browser@^2.2.1:
   version "2.2.1"
@@ -8203,11 +8079,6 @@ react-shadow@^19.0.3:
   dependencies:
     humps "^2.0.1"
     react-use "^15.3.3"
-
-react-supabase@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/react-supabase/-/react-supabase-0.2.0.tgz#63b1083e18754b5a0e6946ef4701a0559ba713b5"
-  integrity sha512-dlAOhkFaWr8ZqHUkWflGvDpFUT69DbWE7+LxmH/a56ma/qS1EinsIKcxskPcPlaWO70QI7hxu9y8imp8qxDCLw==
 
 react-universal-interface@^0.6.2:
   version "0.6.2"
@@ -9658,11 +9529,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
-
 trough@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
@@ -9724,23 +9590,6 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
-  integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
-
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -9972,13 +9821,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-utf-8-validate@^5.0.2:
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.9.tgz#ba16a822fbeedff1a58918f2a6a6b36387493ea3"
-  integrity sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==
-  dependencies:
-    node-gyp-build "^4.3.0"
-
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -10125,11 +9967,6 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
-
 webpack-dev-middleware@3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz#0019c3db716e3fa5cecbf64f2ab88a74bab331f3"
@@ -10274,26 +10111,6 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-websocket@^1.0.34:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
-  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
-  dependencies:
-    bufferutil "^4.0.1"
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    typedarray-to-buffer "^3.1.5"
-    utf-8-validate "^5.0.2"
-    yaeti "^0.0.6"
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
-
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -10432,11 +10249,6 @@ y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
-
-yaeti@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
-  integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,10 +1105,39 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@eslint/eslintrc@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
+  integrity sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.3.2"
+    globals "^13.15.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
+  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@insin/npm-install-webpack-plugin@5.0.0":
   version "5.0.0"
@@ -1540,10 +1569,20 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
+acorn@^8.7.1:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 address@^1.0.1:
   version "1.1.2"
@@ -1573,7 +1612,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1676,6 +1715,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2402,6 +2446,11 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camel-case@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
@@ -2477,6 +2526,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2993,6 +3050,15 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -3259,7 +3325,7 @@ debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.4:
+debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3301,6 +3367,11 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^2.1.1:
   version "2.2.1"
@@ -3465,6 +3536,13 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -3807,6 +3885,16 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -3815,12 +3903,94 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint@^8.20.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.20.0.tgz#048ac56aa18529967da8354a478be4ec0a2bc81b"
+  integrity sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==
+  dependencies:
+    "@eslint/eslintrc" "^1.3.0"
+    "@humanwhocodes/config-array" "^0.9.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.1"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.2"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^6.0.1"
+    globals "^13.15.0"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    regexpp "^3.2.0"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
+  integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
+  dependencies:
+    acorn "^8.7.1"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esrecurse@^4.1.0:
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.1.0, esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
@@ -3832,7 +4002,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -4043,6 +4213,11 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
 fast-shallow-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
@@ -4092,6 +4267,13 @@ figures@3.2.0, figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-loader@6.0.0:
   version "6.0.0"
@@ -4179,6 +4361,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flat@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.1.tgz#a392059cc382881ff98642f5da4dde0a959f309b"
@@ -4190,6 +4380,11 @@ flatted@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flatted@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
+  integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
 
 flatted@^3.2.5:
   version "3.2.5"
@@ -4359,6 +4554,11 @@ function.prototype.name@^1.1.5:
     es-abstract "^1.19.0"
     functions-have-names "^1.2.2"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
 functions-have-names@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.2.tgz#98d93991c39da9361f8e50b337c4f6e41f120e21"
@@ -4430,6 +4630,13 @@ glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob@7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -4458,6 +4665,13 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^13.15.0:
+  version "13.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
+  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
+  dependencies:
+    type-fest "^0.20.2"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -4877,6 +5091,14 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 import-from@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
@@ -5253,7 +5475,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -5555,6 +5777,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -5584,6 +5813,11 @@ json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -5796,6 +6030,14 @@ levenary@^1.1.1:
   dependencies:
     leven "^3.1.0"
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -5848,6 +6090,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -6364,7 +6611,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -6587,6 +6834,11 @@ native-url@^0.2.6:
   integrity sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==
   dependencies:
     querystring "^0.2.0"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -6982,6 +7234,18 @@ optimize-css-assets-webpack-plugin@5.0.3:
     cssnano "^4.1.10"
     last-call-webpack-plugin "^3.0.0"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 ora@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/ora/-/ora-4.0.4.tgz#e8da697cc5b6a47266655bf68e0fb588d29a545d"
@@ -7084,6 +7348,13 @@ param-case@^3.0.3:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.6"
@@ -7620,10 +7891,20 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.27, postcss@^7.0.3
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-error@^2.1.1:
   version "2.1.2"
@@ -7658,7 +7939,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.0.0, prop-types@^15.6.2:
+prop-types@^15.0.0:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7865,15 +8146,14 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"
@@ -7954,14 +8234,13 @@ react-use@^15.3.3:
     ts-easing "^0.2.0"
     tslib "^2.0.0"
 
-react@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
@@ -8063,6 +8342,11 @@ regexp.prototype.flags@^1.2.0:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 regexpu-core@^5.0.1:
   version "5.0.1"
@@ -8216,6 +8500,11 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-from@^5.0.0:
   version "5.0.0"
@@ -8375,10 +8664,10 @@ sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -9053,6 +9342,11 @@ strip-json-comments@2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 style-loader@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.1.tgz#c5cbbfbf1170d076cfdd86e0109c5bba114baa1a"
@@ -9224,6 +9518,11 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 throttle-debounce@^2.1.0:
   version "2.3.0"
@@ -9400,6 +9699,18 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -9730,6 +10041,11 @@ uvu@^0.5.0:
     kleur "^4.0.3"
     sade "^1.7.3"
 
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -10054,6 +10370,11 @@ wide-align@1.1.3:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+word-wrap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
This PR removes supabase completely, replacing all supabase calls with internal REST API calls. This will be a backwards-incompatible major version bump for this library.

There are a few key differences from how this implementation communicates with the new internal squeak API vs how supabase does things.

### Sessions

Supabase handles sessions via JWTs. You authenticate with supabase, and they issue a JWT which is passed to the client in a plain-text cookie. We were then passing this along to the internal API for calls that required a concept of the "current" user according to supabase.

In the new setup, we just use encrypted session cookies rather than JWTs. We have the ability to add JWTs support -- the server supports this currently via passport-jwt -- but I didn't see a need for the additional overhead of JWTs vs session cookies.

### Readonly-profile `metadata` property name change

In the previous api, we were using a feature of the supabase client to essentially do a join from the `squeak_profiles` table to the `squeak_profiles_readonly` table (essentially a mapping of profiles to org ids to roles -- we should rename this) and map some of the properties from `squeak_profiles_readonly` onto a property called `metadata` on the `profile` object. Now, this property is simply called `profile_readonly` to reflect it's name in the prisma schema.