### PR TITLE
Pass email address to onSubmit handler

### DIFF
--- a/src/components/QuestionForm.js
+++ b/src/components/QuestionForm.js
@@ -15,11 +15,12 @@ function QuestionForm({
   onSubmit,
   subject = true,
   loading,
-  initialValues
+  initialValues,
+  formType
 }) {
   const { user } = useUser()
   const handleSubmit = async (values) => {
-    onSubmit && (await onSubmit(values))
+    onSubmit && (await onSubmit({ ...values, email: user?.email }, formType))
   }
   return (
     <div className='squeak-form-frame'>

--- a/src/components/Questions.js
+++ b/src/components/Questions.js
@@ -86,7 +86,7 @@ export default function Questions({
     })
   }, [])
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (values, formType) => {
     getQuestions({ limit: 1, start: 0 }).then((data) => {
       setQuestions([...data.questions, ...questions])
       setCount(data.count)


### PR DESCRIPTION
Adds user email address to onSubmit handler. Helpful if you want to add new users to a CRM when a question is asked.